### PR TITLE
Add piped input to C backend.

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -1,5 +1,5 @@
 use oakc::{compile, Go, C};
-use std::{fs::read_to_string, path::PathBuf, process::exit};
+use std::{fs::read_to_string, io::Result, path::PathBuf, process::exit};
 
 use clap::{clap_app, crate_authors, crate_version, AppSettings::ArgRequiredElseHelp};
 
@@ -41,7 +41,7 @@ fn main() {
                 PathBuf::from("./")
             };
 
-            let success = if matches.is_present("c") {
+            let compile_result = if matches.is_present("c") {
                 compile(&cwd, contents, C)
             } else if matches.is_present("go") {
                 compile(&cwd, contents, Go)
@@ -49,10 +49,13 @@ fn main() {
                 compile(&cwd, contents, C)
             };
 
-            if success {
-                println!("compilation was successful");
-            } else {
-                eprintln!("error: failed to compile generated output code");
+            match compile_result {
+                Result::Ok(_) => println!("compilation successful"),
+                Result::Err(error) => {
+                    if let Some(inner_error) = error.get_ref() {
+                        eprintln!("error: {}", inner_error);
+                    }
+                }
             }
         } else {
             eprintln!("error: input file \"{}\" doesn't exist", input_file);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![allow(warnings, clippy, unknown_lints)]
-use std::{path::PathBuf, process::exit};
+use std::{io::Result, path::PathBuf, process::exit};
 pub type Identifier = String;
 pub type StringLiteral = String;
 
@@ -17,7 +17,7 @@ use comment::cpp::strip;
 use lalrpop_util::{lalrpop_mod, ParseError};
 lalrpop_mod!(pub parser);
 
-pub fn compile(cwd: &PathBuf, input: impl ToString, target: impl Target) -> bool {
+pub fn compile(cwd: &PathBuf, input: impl ToString, target: impl Target) -> Result<()> {
     match parse(input).compile(cwd) {
         Ok(mir) => match mir.assemble() {
             Ok(asm) => {

--- a/src/target/go.rs
+++ b/src/target/go.rs
@@ -1,6 +1,7 @@
 use super::Target;
 use std::{
     fs::{remove_file, write},
+    io::{Error, ErrorKind, Result},
     process::Command,
 };
 
@@ -86,14 +87,14 @@ impl Target for Go {
         String::from("}\n")
     }
 
-    fn compile(&self, code: String) -> bool {
+    fn compile(&self, code: String) -> Result<()> {
         if let Ok(_) = write("main.go", code) {
             if let Ok(_) = Command::new("go").arg("build").arg("main.go").output() {
                 if let Ok(_) = remove_file("main.go") {
-                    return true;
+                    return Result::Ok(());
                 }
             }
         }
-        false
+        Result::Err(Error::new(ErrorKind::Other, "error compiling "))
     }
 }

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -30,5 +30,5 @@ pub trait Target {
     fn begin_while(&self) -> String;
     fn end_while(&self) -> String;
 
-    fn compile(&self, code: String) -> bool;
+    fn compile(&self, code: String) -> std::io::Result<()>;
 }


### PR DESCRIPTION
This update removes temporary files when compiling with the C
backend and opts to pipe input to GCC. Additionally, the Target
trait now returns std::io::Result<()> rather than a boolean as
this allows for more descriptive backend error reporting.