### PR TITLE
Changes the method of inserting newlines in the standard library

### DIFF
--- a/src/std.ok
+++ b/src/std.ok
@@ -15,12 +15,12 @@ fn gt(x: num, y: num) -> num { gt!(x, y) }
 fn ge(x: num, y: num) -> num { ge!(x, y) }
 
 fn putstr(s: &char) -> void { prs!(s); }
-fn putstrln(s: &char) -> void { putstr(s); putstr("\n"); }
+fn putstrln(s: &char) -> void { putstr(s); prend!(); }
 
 fn putnum(n: num) -> void { prn!(n); }
-fn putnumln(n: num) -> void { putnum(n); putstr("\n"); }
+fn putnumln(n: num) -> void { putnum(n); prend!(); }
 
 fn putchar(ch: char) -> void { prc!(ch); }
-fn putcharln(ch: char) -> void { putchar(ch); putstr("\n"); }
+fn putcharln(ch: char) -> void { putchar(ch); prend!(); }
 
 fn get_char() -> char { getch!(); }


### PR DESCRIPTION
This PR changes `putstr("\n")` to `prend!()` in std.ok. this way, the `put...ln` functions will work with compilation targets that use something other than `\n` for their newline (such as web targets which may use `<br>`)