### PR TITLE
Added return statement and typecast expression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oakc"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Adam McDaniel <adam.mcdaniel17@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -96,23 +96,21 @@ fn main() -> 0 {
 The syntax of oak is heavily inspired by the Rust programming language.
 
 ```rust
-// Flag to include another file in this directory
-#[include("str.ok")]
-
 // An optional flag to set the exact number of memory cells to use for the heap.
 // This makes Oak an extremely suitable language for embedded development!
 #[heap(128)]
 
-// The `1` here is the size of the type on the stack
 type bool(1) {
-    fn true()  -> bool { 1 }
-    fn false() -> bool { 0 }
+    fn true()  -> bool { return 1 as bool }
+    fn false() -> bool { return 0 as bool }
 
-    fn val(self: &bool) -> &num { self }
+    fn val(self: &bool) -> &num { return self as &num }
 
     fn not(self: &bool) -> bool {
-        if *self { bool::false() }
-        else { bool::true() }
+        let result: bool = bool::true();
+        // "self->val" is equivalent to "*self.val()"
+        if self->val { result = bool::false(); }
+        return result
     }
 }
 
@@ -124,10 +122,9 @@ fn main() {
     // assign to b's "val" attribute
     b->val = 1;
     putboolln(b);
-
     b = bool::true();
     putboolln(b);
-    
+
     let size: num = 32;
     // Allocate 32 cells
     let addr: &char = alloc(size);
@@ -137,8 +134,11 @@ fn main() {
 
 
 fn putbool(b: bool) {
-    if b { putstr("true") }
-    else { putstr("false") }
+    if b {
+        putstr("true");
+    } else {
+        putstr("false");
+    }
 }
 
 fn putboolln(b: bool) {
@@ -147,9 +147,11 @@ fn putboolln(b: bool) {
 
 // Functions can be ordered independently
 fn square(x: num) -> num {
-    putstr("Squaring the number '"); putnum(x); putcharln('\'');
+    putstr("Squaring the number '");
+    putnum(x);
+    putcharln('\'');
     // The last statement in a body doesn't require brackets
-    x * x
+    return x * x
 }
 ```
 

--- a/examples/array.ok
+++ b/examples/array.ok
@@ -2,23 +2,23 @@
 const ARRAY = 3;
 type Array(ARRAY) {
     fn new(len: num, elem_size: num) -> Array {
-        len; elem_size; alloc(len * elem_size)
+        return [len, elem_size, alloc(len * elem_size)]
     }
 
     fn len(self: &Array) -> &num {
-        self
+        return self as &num
     }
 
     fn elem_size(self: &Array) -> &num {
-        self + 1
+        return (self + 1) as &num
     }
 
     fn contents(self: &Array) -> &&void {
-        self + 2
+        return (self + 2) as &&void
     }
 
     fn idx(self: &Array, n: num) -> &void {
-        self->contents + (n * (self->elem_size))
+        return self->contents + (n * (self->elem_size))
     }
 
     fn print(self: &Array) -> void {
@@ -36,16 +36,16 @@ type Array(ARRAY) {
 
 const DATE = 3;
 type Date(DATE) {
-    fn from(ptr: &void) -> &Date { ptr }
+    fn from(ptr: &void) -> &Date { return ptr as &Date }
     fn new(month: num, day: num, year: num) -> Date {
-        month; day; year
+        return [month, day, year]
     }
 
-    fn birthday() -> Date { Date::new(5, 14, 2002) }
+    fn birthday() -> Date { return Date::new(5, 14, 2002) }
 
-    fn month(self: &Date) -> &num { self }
-    fn day(self: &Date)   -> &num { self + 1 }
-    fn year(self: &Date)  -> &num { self + 2 }
+    fn month(self: &Date) -> &num { return self as &num }
+    fn day(self: &Date)   -> &num { return (self + 1) as &num }
+    fn year(self: &Date)  -> &num { return (self + 2) as &num }
 
     fn print(self: &Date) -> void {
         prn!(self->month);
@@ -58,12 +58,12 @@ type Date(DATE) {
 
     fn yesterday(self: &Date) -> Date {
         self->day = self->day - 1;
-        *self
+        return *self
     }
 
     fn tomorrow(self: &Date) -> Date {
         self->day = self->day + 1;
-        *self
+        return *self
     }
 
     fn next_week(self: &Date) -> Date {
@@ -71,12 +71,12 @@ type Date(DATE) {
         for (let i:num=0; i<10; i=i+1) {
             result = result.tomorrow();
         }
-        result
+        return result
     }
 
     fn next_month(self: &Date) -> Date {
         self->month = self->month + 1;
-        *self
+        return *self
     }
 }
 

--- a/examples/bf.ok
+++ b/examples/bf.ok
@@ -6,7 +6,7 @@
 
 // Copy a char array
 fn strcpy(dst: &char, src: &char) {
-	for (let i: num=0; src[i]; i = i + 1) {
+	for (let i=0; src[i]; i=i+1) {
 		dst[i] = src[i];
 	}
 	dst[i] = 0;
@@ -14,34 +14,42 @@ fn strcpy(dst: &char, src: &char) {
 
 // Get the length of a char array
 fn strlen(str: &char) -> num {
-	for (let i: num=0; str[i]; i = i + 1) {}
-	i
+	for (let i=0; str[i]; i=i+1) {}
+	return i
 }
 
 const EOF = -1;
 const MAX_LOOP_DEPTH = 32;
 const TAPE_SIZE = 128;
 const MACHINE = 6;
+
 type Machine(MACHINE) {
 	fn new(source_code: &char) -> Machine {
-		let jmp_stack: &num = alloc(MAX_LOOP_DEPTH);
-		let jmp_counter: num = 0;
-		let val_ptr: num = 0;
-		let ins_ptr: num = 0;
-		let code: &char = alloc(strlen(source_code) + 1);
+		let jmp_stack = alloc(MAX_LOOP_DEPTH) as &num;
+		let jmp_counter = 0;
+		let val_ptr = 0;
+		let ins_ptr = 0;
+		let code = alloc(strlen(source_code) + 1) as &char;
 		strcpy(code, source_code);
-		let tape: &num = alloc(TAPE_SIZE);
+		let tape = alloc(TAPE_SIZE) as &num;
 
-		jmp_stack; jmp_counter; val_ptr; ins_ptr; tape; code
+		return [
+			jmp_stack,
+			jmp_counter,
+			val_ptr,
+			ins_ptr,
+			tape,
+			code
+		];
 	}
 
-	fn jmp_stack(self: &Machine)   -> &&num  { self }
-	fn jmp_counter(self: &Machine) -> &num   { self + 1 }
-	fn val_ptr(self: &Machine)     -> &num   { self + 2 }
-	fn ins_ptr(self: &Machine)     -> &num   { self + 3 }
-	fn tape(self: &Machine)        -> &&num  { self + 4 }
-	fn code(self: &Machine)        -> &&char { self + 5 }
-	fn token(self: &Machine)       -> &char  { self->code + self->ins_ptr }
+	fn jmp_stack(self: &Machine)   -> &&num  { return self as &&num }
+	fn jmp_counter(self: &Machine) -> &num   { return (self + 1) as &num }
+	fn val_ptr(self: &Machine)     -> &num   { return (self + 2) as &num }
+	fn ins_ptr(self: &Machine)     -> &num   { return (self + 3) as &num }
+	fn tape(self: &Machine)        -> &&num  { return (self + 4) as &&num }
+	fn code(self: &Machine)        -> &&char { return (self + 5) as &&char }
+	fn token(self: &Machine)       -> &char  { return self->code + self->ins_ptr }
 
 	fn plus(self: &Machine)   { self->val = self->val + 1 }
 	fn minus(self: &Machine)  { self->val = self->val - 1 }
@@ -55,7 +63,7 @@ type Machine(MACHINE) {
 		}
 	}
 
-	fn val(self: &Machine) -> &num { self->tape + self->val_ptr }
+	fn val(self: &Machine) -> &num { return self->tape + self->val_ptr }
 
 	fn loop(self: &Machine) {
 		(self->jmp_stack)[self->jmp_counter] = self->ins_ptr;

--- a/examples/date.ok
+++ b/examples/date.ok
@@ -4,16 +4,16 @@
 const DATE = 3;
 type Date(DATE) {
     fn new(month: num, day: num, year: num) -> Date {
-        month; day; year;
+        return [month, day, year]
     }
 
     fn birthday() -> Date {
-        Date::new(5, 14, 2002);
+        return Date::new(5, 14, 2002);
     }
     
-    fn month(self: &Date) -> &num { self; }
-    fn day(self: &Date)   -> &num { self + 1; }
-    fn year(self: &Date)  -> &num { self + 2; }
+    fn month(self: &Date) -> &num { return self as &num; }
+    fn day(self: &Date)   -> &num { return (self + 1) as &num; }
+    fn year(self: &Date)  -> &num { return (self + 2) as &num; }
 
     fn tomorrow(self: &Date)  { self->day = self->day + 1; }
     fn yesterday(self: &Date) { self->day = self->day - 1; }

--- a/examples/fact.ok
+++ b/examples/fact.ok
@@ -1,12 +1,15 @@
 #[heap(512)]
 
 fn fact(n: num) -> num {
-    if n - 1 { n * fact(n-1) }
-    else { 1 }
+    let result = 1;
+    if n > 1 {
+        result = n * fact(n-1)
+    }
+    return result
 }
 
 fn main() {
-    for (let i: num = 1; i-100; i=i+1) {
+    for (let i=0; i<100; i=i+1) {
         putnum(i); putstr("! is "); putnumln(fact(i));
     }
 }

--- a/examples/file.ok
+++ b/examples/file.ok
@@ -3,13 +3,13 @@
 const FILE = 2;
 type File(FILE) {
     fn open(name: &char) -> File {
-        name; 1;
+        return [name, 1]
     }
 
-    fn name(self: &File) -> &&char { self; }
-    fn is_open(self: &File) -> &num { self + 1; }
+    fn name(self: &File) -> &&char { return self as &&char; }
+    fn is_open(self: &File) -> &num { return (self + 1) as &num; }
 
-    fn read(self: &File) -> &char { "Contents of file!!!"; }
+    fn read(self: &File) -> &char { return "Contents of file!!!"; }
 
     fn close(self: &File) {
         self->is_open = 0;

--- a/examples/if_else.ok
+++ b/examples/if_else.ok
@@ -1,12 +1,13 @@
 
 fn not_(x: num) -> num {
+    let result = 0;
     if x {
         putstrln("x is true");
-        0
+        result = 1
     } else {
         putstrln("x is false");
-        1
     }
+    return result
 }
 
 fn main() {

--- a/examples/include/lib/str.ok
+++ b/examples/include/lib/str.ok
@@ -1,7 +1,7 @@
 
 fn strlen(str: &char) -> num {
     for (let i=0; str[i]; i=i+1) {}
-    i
+    return i
 }
 
 fn strcpy(dst: &char, src: &char) {
@@ -12,7 +12,7 @@ fn strcpy(dst: &char, src: &char) {
 }
 
 fn strcat(dst: &char, src: &char) {
-    let offset: num = strlen(dst);
+    let offset = strlen(dst);
     for (let i=0; src[i]; i=i+1) {
         dst[offset+i] = src[i];
     }

--- a/examples/input.ok
+++ b/examples/input.ok
@@ -1,19 +1,19 @@
 
 fn strlen(str: &char) -> num {
-    for (let i: num=0; str[i]; i=i+1) {}
-    i;
+    for (let i=0; str[i]; i=i+1) {}
+    return i
 }
 
 fn strcpy(dst: &char, src: &char) {
-    for (let i: num=0; src[i]; i=i+1) {
+    for (let i=0; src[i]; i=i+1) {
         dst[i] = src[i];
     }
     dst[i] = 0;
 }
 
 fn strcat(dst: &char, src: &char) {
-    let offset: num = strlen(dst);
-    for (let i: num=0; src[i]; i=i+1) {
+    let offset = strlen(dst);
+    for (let i=0; src[i]; i=i+1) {
         dst[offset+i] = src[i];
     }
     dst[offset+i] = 0;
@@ -21,7 +21,7 @@ fn strcat(dst: &char, src: &char) {
 
 
 fn input(buffer: &char) -> void {
-    let i: num = 0;
+    let i = 0;
     for (let ch = get_char(); neq(ch, '\n'); ch = get_char()) {
         buffer[i] = ch;
         i = i + 1;
@@ -29,9 +29,9 @@ fn input(buffer: &char) -> void {
 }
 
 fn main() -> void {
-    let size: num = 256;
+    let size = 256;
     putstr("Enter some text: ");
-    let s: &char = alloc(size);
+    let s = alloc(size) as &char;
     input(s);
     strcat(s, " take a sad song, and make it better!");
 

--- a/examples/method.ok
+++ b/examples/method.ok
@@ -1,22 +1,22 @@
 
 type Date(3) {
     fn new(month: num, day: num, year: num) -> Date {
-        month; day; year;
+        return [month, day, year]
     }
 
     fn birthday() -> Date {
-        Date::new(5, 14, 2002);
+        return Date::new(5, 14, 2002)
     }
 
-    fn month(self: &Date) -> &num { self; }
-    fn day(self: &Date) -> &num { self + 1; }
-    fn year(self: &Date) -> &num { self + 2; }
+    fn month(self: &Date) -> &num { return self as &num; }
+    fn day(self: &Date)   -> &num { return (self + 1) as &num; }
+    fn year(self: &Date)  -> &num { return (self + 2) as &num; }
 
     fn tmrw(self: &Date) -> Date {
-        Date::new(self->month, self->day + 1, self->year);
+        return Date::new(self->month, self->day + 1, self->year);
     }
 
-    fn print(self: &Date) -> void {
+    fn print(self: &Date) {
         prn!(self->month); prc!('/');
         prn!(self->day); prc!('/');
         prn!(self->year);
@@ -24,15 +24,15 @@ type Date(3) {
 }
 
 type Test(1) {
-    fn new(n: num) -> Test { n; }
-    fn n(self: &Test) -> &num { self; }
+    fn new(n: num) -> Test { return n as Test; }
+    fn n(self: &Test) -> &num { return self as &num; }
 
-    fn print(self: &Test) -> void {
+    fn print(self: &Test) {
         prs!("test: "); prn!(self->n); prend!();
     }
 }
 
-fn test() -> void {
+fn test() {
     let bday: Date = Date::birthday();
     bday.print(); prend!();
     ((bday.tmrw()).tmrw()).print(); prend!();
@@ -41,7 +41,7 @@ fn test() -> void {
 }
 
 fn main() -> void {
-    for (let i: num = 0; i<10; i=i+1) {
+    for (let i=0; i<10; i=i+1) {
         test();
         prn!(i); prend!();
     }

--- a/examples/refer.ok
+++ b/examples/refer.ok
@@ -2,28 +2,30 @@
 
 
 type Counter(1) {
-    fn new() -> Counter { 0 }
+    fn new() -> Counter { return 0 as Counter }
 
-    fn count(self: &Counter) -> &num { self }
+    fn count(self: &Counter) -> &num { return self as &num }
 
-    fn increment(self: &Counter) -> void {
+    fn increment(self: &Counter) {
         self->count = self->count + 1;
     }
 
-    fn decrement(self: &Counter) -> void {
+    fn decrement(self: &Counter) {
         self->count = self->count - 1;
     }
 }
 
-fn inc(c: Counter) -> void {
+fn inc(c: Counter) {
+    // c is a copy, it does not affect the
+    // Counter given to the function
     c.increment();
     c.increment();
     c.increment();
     putnumln(c->count);
 }
 
-fn main() -> void {
-    let c: Counter = Counter::new();
+fn main() {
+    let c = Counter::new();
     putnumln(c->count);
     inc(c);
     putnumln(c->count);

--- a/examples/str.ok
+++ b/examples/str.ok
@@ -1,11 +1,11 @@
 
 fn strlen(str: &char) -> num {
-    for (let i: num=0; str[i]; i=i+1) {}
-    i;
+    for (let i=0; str[i]; i=i+1) {}
+    return i;
 }
 
 fn strcpy(dst: &char, src: &char) {
-    for (let i: num=0; src[i]; i=i+1) {
+    for (let i=0; src[i]; i=i+1) {
         dst[i] = src[i];
     }
     dst[i] = 0;
@@ -13,7 +13,7 @@ fn strcpy(dst: &char, src: &char) {
 
 fn strcat(dst: &char, src: &char) {
     let offset: num = strlen(dst);
-    for (let i: num=0; src[i]; i=i+1) {
+    for (let i=0; src[i]; i=i+1) {
         dst[offset+i] = src[i];
     }
     dst[offset+i] = 0;
@@ -21,11 +21,12 @@ fn strcat(dst: &char, src: &char) {
 
 
 fn main() {
-    let s: &char = alloc(32);
+    let size = 32;
+    let s = alloc(size) as &char;
     strcpy(s, "test");
     putstrln(s);
     strcat(s, "ing");
     putstrln(s);
 
-    free s: 32;
+    free s: size;
 }

--- a/examples/syntax.ok
+++ b/examples/syntax.ok
@@ -4,23 +4,23 @@
 #[heap(128)]
 
 type bool(1) {
-    fn true() -> bool { 1 }
-    fn false() -> bool { 0 }
+    fn true()  -> bool { return 1 as bool }
+    fn false() -> bool { return 0 as bool }
 
-    fn val(self: &bool) -> &num { self }
+    fn val(self: &bool) -> &num { return self as &num }
 
     fn not(self: &bool) -> bool {
         let result: bool = bool::true();
         // "self->val" is equivalent to "*self.val()"
         if self->val { result = bool::false(); }
-        result
+        return result
     }
 }
 
 fn main() {
     putnumln(square(5));
 
-    let b: bool = bool::false();
+    let b = bool::false();
     putboolln(b);
     // assign to b's "val" attribute
     b->val = 1;
@@ -39,9 +39,7 @@ fn main() {
 fn putbool(b: bool) {
     if b {
         putstr("true");
-    }
-
-    if b.not() {
+    } else {
         putstr("false");
     }
 }
@@ -56,5 +54,5 @@ fn square(x: num) -> num {
     putnum(x);
     putcharln('\'');
     // The last statement in a body doesn't require brackets
-    x * x
+    return x * x
 }

--- a/examples/typecheck/bad_cast.ok
+++ b/examples/typecheck/bad_cast.ok
@@ -1,0 +1,12 @@
+
+type Two(2) {
+    fn new() -> Two { return [2, 2] }
+}
+type Three(3) {
+    fn new() -> Three { return [3, 3, 3] }
+}
+
+
+fn main() {
+    let three = Two::new() as Three;
+}

--- a/examples/typecheck/bad_return.ok
+++ b/examples/typecheck/bad_return.ok
@@ -1,0 +1,13 @@
+
+
+type Date(3) {
+    fn new(m: num, d: num, y: num) -> Date {
+        return [m, d, y]
+    }
+}
+
+fn test() -> num {
+    return Date::new(5, 14, 2002)
+}
+
+fn main() {}

--- a/examples/typecheck/bad_return_multi.ok
+++ b/examples/typecheck/bad_return_multi.ok
@@ -1,0 +1,8 @@
+
+
+
+fn test() -> num {
+    return [2, 2];
+}
+
+fn main() {}

--- a/examples/typecheck/define.ok
+++ b/examples/typecheck/define.ok
@@ -1,7 +1,7 @@
 
 type Point(2) {
     fn new(x: num, y: num) -> Point {
-        x; y
+        return [x, y]
     }
 }
 

--- a/examples/typecheck/non_void_no_return.ok
+++ b/examples/typecheck/non_void_no_return.ok
@@ -1,0 +1,6 @@
+
+
+
+fn test() -> num {}
+
+fn main() {}

--- a/examples/typecheck/void_return.ok
+++ b/examples/typecheck/void_return.ok
@@ -1,0 +1,7 @@
+
+
+fn test() {
+    return 1;
+}
+
+fn main() {}

--- a/src/mir.rs
+++ b/src/mir.rs
@@ -69,6 +69,19 @@ pub enum MirError {
     /// The return type of the function does not match the result
     /// of the function
     MismatchedReturnType(String),
+    /// A function attempts to use multiple return statements
+    MultipleReturns(String),
+    /// An expression with non-void type is pushed onto the stack
+    /// without being used by another expression or statement.
+    NonVoidExpressionNotUsed(MirExpression),
+    /// A bad typecast due to mismatched sizes in types. For example,
+    /// a value with size `3` cannot be cast to a number with size `1`
+    MismatchedCastSize(MirExpression, MirType),
+    /// Attempted to use a return statement in a conditional expression,
+    /// such as a while loop or if statement
+    ConditionalReturn(String),
+    /// A non-void function never returns
+    NonVoidNoReturn(String),
 }
 
 /// Print an MIR error on the command line
@@ -140,6 +153,31 @@ impl Display for MirError {
             Self::MismatchedReturnType(fn_name) => write!(
                 f,
                 "the return type of the function '{}' does not match the function's return value",
+                fn_name
+            ),
+            Self::MultipleReturns(fn_name) => write!(
+                f,
+                "the function '{}' uses multiple return statements",
+                fn_name
+            ),
+            Self::NonVoidExpressionNotUsed(expr) => write!(
+                f,
+                "the non-void expression '{}' is used but not consumed by another expression or statement",
+                expr
+            ),
+            Self::MismatchedCastSize(expr, t) => write!(
+                f,
+                "cannot cast expression '{}' to type '{}' due to mismatched sizes",
+                expr, t
+            ),
+            Self::ConditionalReturn(fn_name) => write!(
+                f,
+                "used a return statement within a conditional statement in the function '{}'",
+                fn_name
+            ),
+            Self::NonVoidNoReturn(fn_name) => write!(
+                f,
+                "the non-void function '{}' never returns an expression",
                 fn_name
             ),
         }
@@ -461,12 +499,49 @@ impl MirFunction {
             stmt.type_check(&vars, funcs, structs)?
         }
 
+
+
         // Check return type
-        // if let Some(last_stmt) = self.body.last() {
-        //     if self.return_type != last_stmt.get_type(&vars, funcs, structs)? {
-        //         return Err(MirError::MismatchedReturnType(self.name.clone()))
-        //     }
-        // }
+        let mut has_returned = false;
+        for (i, stmt) in self.body.iter().enumerate() {
+            if let MirStatement::Return(exprs) = stmt {
+                // If the function has already used a return statement,
+                // throw an error.
+                if has_returned {
+                    return Err(MirError::MultipleReturns(self.name.clone()))
+                }
+                has_returned = true;
+
+                // Get the size of the return statement's stack allocation
+                let mut result_size = 0;
+                for expr in exprs {
+                    result_size += expr.get_type(&vars, funcs, structs)?
+                                    .get_size(structs)?;
+                }
+
+                // If the result's size is not equal to the size of the
+                // return type, throw a type error.
+                if result_size != self.return_type.get_size(structs)? {
+                    return Err(MirError::MismatchedReturnType(self.name.clone()))
+
+                // If there is only one return argument, check the individual
+                // expression's type against the return type.
+                } else if exprs.len() == 1 && self.return_type != exprs[0]
+                    .get_type(&vars, funcs, structs)? {
+                    return Err(MirError::MismatchedReturnType(self.name.clone()))
+                }
+            // If a statement has a return statement, but is not a return
+            // statement itself, it must be a conditional return statement
+            } else if stmt.has_return() {
+                return Err(MirError::ConditionalReturn(self.name.clone()))
+            }
+        }
+
+        // If the function is non-void and has not returned,
+        // then throw an error.
+        if !has_returned && self.return_type != MirType::void() {
+            return Err(MirError::NonVoidNoReturn(self.name.clone()))
+        }
 
         Ok(AsmFunction::new(
             self.name.clone(),
@@ -503,6 +578,7 @@ pub enum MirStatement {
     IfElse(MirExpression, Vec<Self>, Vec<Self>),
 
     Free(MirExpression, MirExpression),
+    Return(Vec<MirExpression>),
     Expression(MirExpression),
 }
 
@@ -517,6 +593,46 @@ impl MirStatement {
             expr.get_type(vars, funcs, structs)
         } else {
             Ok(MirType::void())
+        }
+    }
+
+    /// Does this statement eventually result in a return statement?
+    fn has_return(&self) -> bool {
+        match self {
+            Self::For(pre, _, post, body) => {
+                let mut result = false;
+                for stmt in body {
+                    result = result || stmt.has_return();
+                }
+                result || pre.has_return() || post.has_return()
+            }
+
+            Self::While(_, body) => {
+                for stmt in body {
+                    if stmt.has_return() { return true }
+                }
+                false
+            }
+
+            Self::If(_, body) => {
+                for stmt in body {
+                    if stmt.has_return() { return true }
+                }
+                false
+            }
+
+            Self::IfElse(_, then_body, else_body) => {
+                for stmt in then_body {
+                    if stmt.has_return() { return true }
+                }
+                for stmt in else_body {
+                    if stmt.has_return() { return true }
+                }
+                false
+            }
+
+            Self::Return(_) => true,
+            _ => false
         }
     }
 
@@ -642,6 +758,12 @@ impl MirStatement {
                 }
             }
 
+            Self::Return(exprs) => {
+                for expr in exprs {
+                    expr.type_check(vars, funcs, structs)?
+                }
+            }
+
             Self::Free(address, size) => {
                 address.type_check(vars, funcs, structs)?;
                 size.type_check(vars, funcs, structs)?;
@@ -652,7 +774,16 @@ impl MirStatement {
                 }
             }
 
-            Self::Expression(expr) => expr.type_check(vars, funcs, structs)?,
+            Self::Expression(expr) => {
+                expr.type_check(vars, funcs, structs)?;
+                if let MirExpression::ForeignCall(_, _) = expr {
+                    // If the expression is a foreign call, then we
+                    // trust that the user is calling a void foreign
+                    // function.
+                } else if expr.get_type(vars, funcs, structs)?.get_size(structs)? != 0 {
+                    return Err(MirError::NonVoidExpressionNotUsed(expr.clone()))
+                }
+            },
         }
         Ok(())
     }
@@ -848,6 +979,14 @@ impl MirStatement {
                 ]
             }
 
+            Self::Return(exprs) => {
+                let mut result = Vec::new();
+                for expr in exprs {
+                    result.extend(expr.assemble(vars, funcs, structs)?)
+                }
+                result
+            }
+
             /// Freeing an address does not return a value, so it is a statement.
             Self::Free(addr, size) => {
                 let mut result = Vec::new();
@@ -883,6 +1022,7 @@ pub enum MirExpression {
     Refer(Identifier),
     Deref(Box<Self>),
 
+    TypeCast(Box<Self>, MirType),
     Alloc(Box<Self>),
 
     Call(Identifier, Vec<Self>),
@@ -899,6 +1039,18 @@ impl MirExpression {
         structs: &BTreeMap<Identifier, MirStructure>,
     ) -> Result<(), MirError> {
         match self {
+            // Typecheck a typecast
+            Self::TypeCast(expr, t) => {
+                expr.type_check(vars, funcs, structs)?;
+
+                // If the expression and cast type have different sizes,
+                // then the expression cannot be cast to this type.
+                if expr.get_type(vars, funcs, structs)?
+                       .get_size(structs) != t.get_size(structs) {
+                    return Err(MirError::MismatchedCastSize(*expr.clone(), t.clone()))
+                }
+            }
+
             // Typecheck binary operations
             // Currently, type checking only fails if either the left hand side
             // or the right hand side are of type `void`, or a user defined structure
@@ -1046,6 +1198,11 @@ impl MirExpression {
         structs: &BTreeMap<Identifier, MirStructure>,
     ) -> Result<Vec<AsmStatement>, MirError> {
         Ok(match self {
+            /// A typecast is only a way to explicitly validate
+            /// some kinds of typechecks. The typecast expression
+            /// has no change on the output code.
+            Self::TypeCast(expr, _) => expr.assemble(vars, funcs, structs)?,
+
             /// Is the LHS greater than or equal the RHS?
             Self::GreaterEqual(l, r) => {
                 let mut result = Vec::new();
@@ -1300,6 +1457,11 @@ impl MirExpression {
         structs: &BTreeMap<Identifier, MirStructure>,
     ) -> Result<MirType, MirError> {
         Ok(match self {
+            /// A typecast simply masks the type of the cast expression.
+            /// The typecast has the type of whichever type the
+            /// expression is being cast to.
+            Self::TypeCast(_, t) => t.clone(),
+
             /// Arithmetic returns the type of the left hand side
             Self::Add(l, _) | Self::Subtract(l, _) | Self::Multiply(l, _) | Self::Divide(l, _) => {
                 l.get_type(vars, funcs, structs)?
@@ -1387,6 +1549,7 @@ impl MirExpression {
 impl Display for MirExpression {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         match self {
+            Self::TypeCast(expr, t) => write!(f, "{} as {}", expr, t),
             Self::Add(lhs, rhs) => write!(f, "{}+{}", lhs, rhs),
             Self::Subtract(lhs, rhs) => write!(f, "{}-{}", lhs, rhs),
             Self::Multiply(lhs, rhs) => write!(f, "{}/{}", lhs, rhs),

--- a/src/parser.lalrpop
+++ b/src/parser.lalrpop
@@ -102,6 +102,8 @@ BodyStatement: HirStatement = {
 }
 
 SmallStatement: HirStatement = {
+    "return" <exprs:List<"[", Expression, ",", "]">> => HirStatement::Return(exprs),
+    "return" <expr:Expression> => HirStatement::Return(vec![expr]),
     "free" <addr:Expression> ":" <size:Expression> => HirStatement::Free(addr, size),
     "let" <name:Ident> "=" <expr:Expression> => HirStatement::AutoDefine(name, expr),
     "let" <name:Ident> ":" <t:Type> "=" <expr:Expression> => HirStatement::Define(name, t, expr),
@@ -114,8 +116,9 @@ SmallStatement: HirStatement = {
 }
 
 Expression: HirExpression = {
+    <expr:ExpressionAtom> "as" <t:Type> => HirExpression::TypeCast(Box::new(expr), t),
+    "*" <ptr:ExpressionBottom> => HirExpression::Deref(Box::new(ptr)),
     <ExpressionBottom> => <>,
-    "*" <ptr:ExpressionAtom> => HirExpression::Deref(Box::new(ptr)),
 }
 
 ExpressionAtom: HirExpression = {

--- a/src/std.ok
+++ b/src/std.ok
@@ -1,12 +1,14 @@
 fn not(x: num) -> num {
-    if x { 0 }
-    else { 1 }
+    let result = 1;
+    if x { result = 0 }
+    return result
 }
 
-fn neq(a: num, b: num) -> num { not(eq(a, b)); }
+fn neq(a: num, b: num) -> num { return not(eq(a, b)); }
 fn eq(a: num, b: num) -> num {
-    if a - b { 0 }
-    else { 1 }
+    let result = 1;
+    if a - b { result = 0 }
+    return result
 }
 
 fn putstr(s: &char) -> void { prs!(s); }
@@ -18,4 +20,4 @@ fn putnumln(n: num) -> void { putnum(n); prend!(); }
 fn putchar(ch: char) -> void { prc!(ch); }
 fn putcharln(ch: char) -> void { putchar(ch); prend!(); }
 
-fn get_char() -> char { getch!(); }
+fn get_char() -> char { return getch!() as char; }


### PR DESCRIPTION
This pull request adds the `return` statement, and the `as` expression.

The return expression can either return a single value or multiple values.
```rust
type Date(3) {
  fn new(m: num, d: num, y: num) -> Date {
    // the return of multiple values is typechecked to confirm that they
    // match the size of the specified return type
    return [m, d, y]
  }
}

fn test() -> num { return 1 }
fn main() {}
```

With the addition of the `return` statement, there are significantly more typechecks. Now, statements that are _not_ return statements may not have a non-void type.

```rust
fn main() {
     5; // error
     let _ = 5; // discard works fine
}
```

Additionally, the `as` expression allows changing the types of values to a type of the same size.

```rust
type Date(3) {
  fn new(m: num, d: num, y: num) -> Date { return [m, d, y] }
  fn month(self: &Date) -> &num { return self as &num } // cast self, which is a &Date, to a &num
}

fn main() {
    let n = Date::new(5, 14, 2002) as num; // bad cast!
}
```