### PR TITLE
Allow the & operator to be applied to indexes and member methods

### DIFF
--- a/examples/array.ok
+++ b/examples/array.ok
@@ -18,7 +18,7 @@ type Array(ARRAY) {
     }
 
     fn idx(self: &Array, n: num) -> &void {
-        return self->contents + (n * (self->elem_size))
+        return self->contents + n * (self->elem_size)
     }
 
     fn print(self: &Array) -> void {

--- a/examples/array_refer.ok
+++ b/examples/array_refer.ok
@@ -1,0 +1,20 @@
+#[std]
+
+type Thing(1) {
+    fn new(n: num) -> Thing {
+        return n as Thing;
+    }
+    fn member(self: &Thing) -> &num { return self as &num }
+}
+
+fn main() {
+    let t = Thing::new(197);
+    putstr("Address of t->member: ");
+    putnumln((&t->member) as num);
+
+    let arr = alloc(32) as &num;
+    putstr("Address of arr[0]: ");
+    putnumln((&arr[0]) as num); // same as `putnumln(arr)`
+    putstr("Address of arr[2]: ");
+    putnumln((&arr[2]) as num); // same as `putnumln(arr + 2 * sizeof(num))`
+}

--- a/src/parser.lalrpop
+++ b/src/parser.lalrpop
@@ -132,10 +132,10 @@ ExpressionAtom: HirExpression = {
     <Num> => HirExpression::Constant(HirConstant::Float(<>)),
     <Char> => HirExpression::Constant(HirConstant::Character(<>)),
 
-    "&" <name:Ident> => HirExpression::Refer(name),
     "(" <Expression> ")" => <>,
     "-" <ExpressionAtom> => HirExpression::Subtract(Box::new(HirExpression::Constant(HirConstant::Float(0.0))), Box::new(<>)),
 }
+
 
 ExpressionBottom: HirExpression = {
     <l:ExpressionLow> ">=" <r:ExpressionLow> => HirExpression::GreaterEqual(Box::new(l), Box::new(r)),
@@ -152,6 +152,10 @@ ExpressionLow: HirExpression = {
 }
 
 ExpressionHigh: HirExpression = {
+    "&" <ptr:ExpressionAtom> "[" <idx:Expression> "]" => HirExpression::Index(Box::new(ptr), Box::new(idx)),
+    "&" <instance:ExpressionAtom> "->" <name:Ident> <args:List<"(", Expression, ",", ")">> => HirExpression::Method(Box::new(instance), name, args),
+    "&" <instance:ExpressionAtom> "->" <name:Ident> => HirExpression::Method(Box::new(instance), name, vec![]),
+    "&" <name:Ident> => HirExpression::Refer(name),
     <ptr:ExpressionAtom> "[" <idx:Expression> "]" => HirExpression::Deref(Box::new(HirExpression::Index(Box::new(ptr), Box::new(idx)))),
     <instance:ExpressionAtom> "." <name:Ident> <args:List<"(", Expression, ",", ")">> => HirExpression::Method(Box::new(instance), name, args),
     <instance:ExpressionAtom> "." <name:Ident> => HirExpression::Method(Box::new(instance), name, vec![]),


### PR DESCRIPTION
This PR allows the `&` operator to be applied to more than a variable name. Now, the following code works.

```rust
type Thing(1) {
    fn new(n: num) -> Thing {
        return n;
    }
    fn member(self: &Thing) -> &num { return self as &num }
}

fn main() {
    let t = Thing::new();
    putstr("Address of t->member: ");
    putnumln(&t->member);

    let arr = alloc(32) as &num;
    putstr("Address of arr[0]: ");
    putnumln(&arr[0]); // same as `putnumln(arr)`
    putstr("Address of arr[2]: ");
    putnumln(&arr[2]); // same as `putnumln(arr + 2 * sizeof(num))`
}
```