### PR TITLE
Implemented && and || for const and non-const expressions

### DIFF
--- a/examples/and_or.ok
+++ b/examples/and_or.ok
@@ -1,0 +1,54 @@
+
+const true = 1 || 0;
+const false = 0 && 1;
+
+
+fn main() {
+    if (true && true) {
+        putstrln("true && true is true! :)")
+    } else {
+        putstrln("true && true is false :(")
+    }
+
+    if (true && false) {
+        putstrln("true && false is true :(")
+    } else {
+        putstrln("true && false is false! :)")
+    }
+
+    if (false && true) {
+        putstrln("false && true is true :(")
+    } else {
+        putstrln("false && true is false! :)")
+    }
+
+    if (false && false) {
+        putstrln("false && false is true :(")
+    } else {
+        putstrln("false && false is false! :)")
+    }
+
+    if (true || true) {
+        putstrln("true || true is true! :)")
+    } else {
+        putstrln("true || true is false :(")
+    }
+
+    if (true || false) {
+        putstrln("true || false is true! :)")
+    } else {
+        putstrln("true || false is false :(")
+    }
+
+    if (false || true) {
+        putstrln("false || true is true! :)")
+    } else {
+        putstrln("false || true is false :(")
+    }
+
+    if (false || false) {
+        putstrln("false || false is true :(")
+    } else {
+        putstrln("false || false is false! :)")
+    }
+}

--- a/src/hir.rs
+++ b/src/hir.rs
@@ -282,6 +282,9 @@ pub enum HirConstant {
     Multiply(Box<Self>, Box<Self>),
     Divide(Box<Self>, Box<Self>),
 
+    And(Box<Self>, Box<Self>),
+    Or(Box<Self>, Box<Self>),
+
     Greater(Box<Self>, Box<Self>),
     Less(Box<Self>, Box<Self>),
     GreaterEqual(Box<Self>, Box<Self>),
@@ -304,6 +307,8 @@ impl Display for HirConstant {
             Self::Subtract(l, r) => write!(f, "{}-{}", l, r),
             Self::Multiply(l, r) => write!(f, "{}*{}", l, r),
             Self::Divide(l, r) => write!(f, "{}/{}", l, r),
+            Self::And(l, r) => write!(f, "{}&&{}", l, r),
+            Self::Or(l, r) => write!(f, "{}||{}", l, r),
             Self::Greater(l, r) => write!(f, "{}>{}", l, r),
             Self::Less(l, r) => write!(f, "{}<{}", l, r),
             Self::GreaterEqual(l, r) => write!(f, "{}>={}", l, r),
@@ -326,6 +331,21 @@ impl HirConstant {
         Ok(match self {
             Self::Float(n) => *n,
             Self::Character(ch) => *ch as u8 as f64,
+
+            Self::And(l, r) => {
+                if l.to_value(constants, target)? != 0.0 && r.to_value(constants, target)? != 0.0 {
+                    1.0
+                } else {
+                    0.0
+                }
+            }
+            Self::Or(l, r) => {
+                if l.to_value(constants, target)? != 0.0 || r.to_value(constants, target)? != 0.0 {
+                    1.0
+                } else {
+                    0.0
+                }
+            }
 
             Self::Equal(l, r) => {
                 if l.to_value(constants, target)? == r.to_value(constants, target)? {
@@ -539,6 +559,9 @@ pub enum HirExpression {
     Divide(Box<Self>, Box<Self>),
 
     Not(Box<Self>),
+    And(Box<Self>, Box<Self>),
+    Or(Box<Self>, Box<Self>),
+
     Greater(Box<Self>, Box<Self>),
     Less(Box<Self>, Box<Self>),
     GreaterEqual(Box<Self>, Box<Self>),
@@ -579,6 +602,14 @@ impl HirExpression {
 
             Self::Not(expr) => MirExpression::Not(
                 Box::new(expr.to_mir_expr(constants, target)?),
+            ),
+            Self::And(l, r) => MirExpression::And(
+                Box::new(l.to_mir_expr(constants, target)?),
+                Box::new(r.to_mir_expr(constants, target)?),
+            ),
+            Self::Or(l, r) => MirExpression::Or(
+                Box::new(l.to_mir_expr(constants, target)?),
+                Box::new(r.to_mir_expr(constants, target)?),
             ),
 
             Self::Greater(l, r) => MirExpression::Greater(

--- a/src/parser.lalrpop
+++ b/src/parser.lalrpop
@@ -63,16 +63,22 @@ ConstantAtom: HirConstant = {
 }
 
 ConstantMathBottom: HirConstant = {
-    <l:ConstantMathLow> "==" <r:ConstantMathLow> => HirConstant::Equal(Box::new(l), Box::new(r)),
-    <l:ConstantMathLow> "!=" <r:ConstantMathLow> => HirConstant::NotEqual(Box::new(l), Box::new(r)),
-    <l:ConstantMathLow> ">=" <r:ConstantMathLow> => HirConstant::GreaterEqual(Box::new(l), Box::new(r)),
-    <l:ConstantMathLow> ">" <r:ConstantMathLow> => HirConstant::Greater(Box::new(l), Box::new(r)),
-    <l:ConstantMathLow> "<=" <r:ConstantMathLow> => HirConstant::LessEqual(Box::new(l), Box::new(r)),
-    <l:ConstantMathLow> "<" <r:ConstantMathLow> => HirConstant::Less(Box::new(l), Box::new(r)),
+    <l:ConstantMathLow> "&&" <r:ConstantMathLow> => HirConstant::And(Box::new(l), Box::new(r)),
+    <l:ConstantMathLow> "||" <r:ConstantMathLow> => HirConstant::Or(Box::new(l), Box::new(r)),
     <ConstantMathLow> => <>
 }
 
 ConstantMathLow: HirConstant = {
+    <l:ConstantMathMiddle> "==" <r:ConstantMathMiddle> => HirConstant::Equal(Box::new(l), Box::new(r)),
+    <l:ConstantMathMiddle> "!=" <r:ConstantMathMiddle> => HirConstant::NotEqual(Box::new(l), Box::new(r)),
+    <l:ConstantMathMiddle> ">=" <r:ConstantMathMiddle> => HirConstant::GreaterEqual(Box::new(l), Box::new(r)),
+    <l:ConstantMathMiddle> ">" <r:ConstantMathMiddle> => HirConstant::Greater(Box::new(l), Box::new(r)),
+    <l:ConstantMathMiddle> "<=" <r:ConstantMathMiddle> => HirConstant::LessEqual(Box::new(l), Box::new(r)),
+    <l:ConstantMathMiddle> "<" <r:ConstantMathMiddle> => HirConstant::Less(Box::new(l), Box::new(r)),
+    <ConstantMathMiddle> => <>
+}
+
+ConstantMathMiddle: HirConstant = {
     <l:ConstantMathHigh> "+" <r:ConstantMathHigh> => HirConstant::Add(Box::new(l), Box::new(r)),
     <l:ConstantMathHigh> "-" <r:ConstantMathHigh> => HirConstant::Subtract(Box::new(l), Box::new(r)),
     <ConstantMathHigh> => <>
@@ -156,16 +162,22 @@ ExpressionAtom: HirExpression = {
 }
 
 ExpressionBottom: HirExpression = {
-    <l:ExpressionLow> "==" <r:ExpressionLow> => HirExpression::Equal(Box::new(l), Box::new(r)),
-    <l:ExpressionLow> "!=" <r:ExpressionLow> => HirExpression::NotEqual(Box::new(l), Box::new(r)),
-    <l:ExpressionLow> ">=" <r:ExpressionLow> => HirExpression::GreaterEqual(Box::new(l), Box::new(r)),
-    <l:ExpressionLow> ">" <r:ExpressionLow> => HirExpression::Greater(Box::new(l), Box::new(r)),
-    <l:ExpressionLow> "<=" <r:ExpressionLow> => HirExpression::LessEqual(Box::new(l), Box::new(r)),
-    <l:ExpressionLow> "<" <r:ExpressionLow> => HirExpression::Less(Box::new(l), Box::new(r)),
+    <l:ExpressionLow> "&&" <r:ExpressionLow> => HirExpression::And(Box::new(l), Box::new(r)),
+    <l:ExpressionLow> "||" <r:ExpressionLow> => HirExpression::Or(Box::new(l), Box::new(r)),
     <ExpressionLow> => <>
 }
 
 ExpressionLow: HirExpression = {
+    <l:ExpressionMiddle> "==" <r:ExpressionMiddle> => HirExpression::Equal(Box::new(l), Box::new(r)),
+    <l:ExpressionMiddle> "!=" <r:ExpressionMiddle> => HirExpression::NotEqual(Box::new(l), Box::new(r)),
+    <l:ExpressionMiddle> ">=" <r:ExpressionMiddle> => HirExpression::GreaterEqual(Box::new(l), Box::new(r)),
+    <l:ExpressionMiddle> ">" <r:ExpressionMiddle> => HirExpression::Greater(Box::new(l), Box::new(r)),
+    <l:ExpressionMiddle> "<=" <r:ExpressionMiddle> => HirExpression::LessEqual(Box::new(l), Box::new(r)),
+    <l:ExpressionMiddle> "<" <r:ExpressionMiddle> => HirExpression::Less(Box::new(l), Box::new(r)),
+    <ExpressionMiddle> => <>
+}
+
+ExpressionMiddle: HirExpression = {
     <l:ExpressionHigh> "+" <r:ExpressionHigh> => HirExpression::Add(Box::new(l), Box::new(r)),
     <l:ExpressionHigh> "-" <r:ExpressionHigh> => HirExpression::Subtract(Box::new(l), Box::new(r)),
     <ExpressionHigh> => <>


### PR DESCRIPTION
The `&&` and `||` (boolean "and" and "or") operators have been implemented for constant expressions and non-constant expressions.

```rust
const X = 1;
const Y = X && 0;

fn main() {
    if (1 || 0) {
        putstr("Y is "); putnumln(X);
    }
}
```