### PR TITLE
Fix/parser

### DIFF
--- a/examples/date.ok
+++ b/examples/date.ok
@@ -29,9 +29,7 @@ type Date(DATE) {
             prn!(self->month); prc!('/');
             prn!(self->day); prc!('/');
             prn!(self->year); 
-        }
-
-        if not(is_american) {
+        } else {
             prn!(self->day); prc!('/');
             prn!(self->month); prc!('/');
             prn!(self->year); 

--- a/examples/ffi/lib/foreign.c
+++ b/examples/ffi/lib/foreign.c
@@ -1,5 +1,5 @@
 
 
 void test(machine *vm) {
-    printf("This is a C foreign function!");
+    printf("This is a C foreign function!\n");
 }

--- a/examples/parse_type.ok
+++ b/examples/parse_type.ok
@@ -1,0 +1,18 @@
+
+
+
+fn ref_one(ptr: &void) -> &&void {
+    return &ptr;
+}
+
+fn ref_two(ptr: &&void) -> &&&void {
+    return &ptr;
+}
+
+fn ref_three(ptr: &&&void) -> &&&&void {
+    return &ptr;
+}
+
+fn main() {
+    let _ = ref_three(ref_two(ref_one(alloc(32))));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ pub fn parse(input: impl ToString) -> HirProgram {
         Ok(parsed) => parsed,
         // if the parser succeeds, annotate code with comments
         Err(e) => {
-            eprintln!("{}", format_error(&code, e));
+            eprintln!("{}", format_error(&code, e.clone()));
             exit(1);
         }
     }

--- a/src/parser.lalrpop
+++ b/src/parser.lalrpop
@@ -106,6 +106,7 @@ Body: Vec<HirStatement> = "{" <head: Statement*> <tail: SmallStatement?> "}" => 
 
 Type: HirType = {
     "&" <t:Type> => HirType::Pointer(Box::new(t)),
+    "&&" <t:Type> => HirType::Pointer(Box::new(HirType::Pointer(Box::new(t)))),
     "void" => HirType::Void,
     "num"  => HirType::Float,
     "char" => HirType::Character,

--- a/src/target/go.rs
+++ b/src/target/go.rs
@@ -103,6 +103,6 @@ impl Target for Go {
                 }
             }
         }
-        Result::Err(Error::new(ErrorKind::Other, "error compiling "))
+        Result::Err(Error::new(ErrorKind::Other, "could not compile output golang code. is golang installed?"))
     }
 }


### PR DESCRIPTION
There was a pretty significant bug in the parser that caused errors like the following:
```
   |
16 | fn contents(self: &Array) -> &&void {
   |                              ^-
   |
   = unexpected `&&`
```

I dug deeper, and I found that the parser was lexing the token as `&&` instead of `&` while trying to parse the type, which should not have happened at all. This must be because the `&&` operator was introduced in the last PR, and it had unintended consequences in the tokenization process. I think this is a bug in LALRPOP.

To fix the problem, I added the following patch:
```rust
Type: HirType = {
    "&" <t:Type> => HirType::Pointer(Box::new(t)),
    // The new condition for parsing types with a "&&" token.
    "&&" <t:Type> => HirType::Pointer(Box::new(HirType::Pointer(Box::new(t)))),
    "void" => HirType::Void,
    "num"  => HirType::Float,
    "char" => HirType::Character,
    <Ident> => HirType::Structure(<>)
}
```
This parses types correctly in the event that any of the `&` characters become grouped in pairs.