### PR TITLE
Fixed problem where types' functions could not be used before declaration

### DIFF
--- a/examples/type.ok
+++ b/examples/type.ok
@@ -1,0 +1,12 @@
+
+
+
+fn main() {
+    let t = T::new()
+}
+
+type T(1) {
+    fn new() -> T {
+        return 1 as T;
+    }
+}

--- a/src/hir.rs
+++ b/src/hir.rs
@@ -785,7 +785,12 @@ pub enum HirExpression {
 impl HirExpression {
     pub fn is_literal(&self) -> bool {
         match self {
-            Self::Void | Self::True | Self::False | Self::Character(_) | Self::String(_) | Self::Constant(_) => true,
+            Self::Void
+            | Self::True
+            | Self::False
+            | Self::Character(_)
+            | Self::String(_)
+            | Self::Constant(_) => true,
             _ => false,
         }
     }

--- a/src/mir.rs
+++ b/src/mir.rs
@@ -359,7 +359,9 @@ impl MirProgram {
         for decl in &decls {
             match decl {
                 MirDeclaration::Function(func) => func.declare(&mut funcs)?,
-                MirDeclaration::Structure(structure) => structure.declare(&mut funcs, &mut structs)?,
+                MirDeclaration::Structure(structure) => {
+                    structure.declare(&mut funcs, &mut structs)?
+                }
                 MirDeclaration::Extern(filename) => externs.push(filename.clone()),
             }
         }
@@ -422,10 +424,11 @@ impl MirStructure {
     }
 
     /// Declare the structure to the compiler WITHOUT assembling it
-    fn declare(&self, 
+    fn declare(
+        &self,
         funcs: &mut BTreeMap<Identifier, MirFunction>,
-        structs: &mut BTreeMap<Identifier, MirStructure>) -> Result<(), MirError> {
-
+        structs: &mut BTreeMap<Identifier, MirStructure>,
+    ) -> Result<(), MirError> {
         // Check if the structure has already been declared
         if structs.contains_key(&self.name) {
             return Err(MirError::StructureRedefined(self.get_name()));
@@ -435,8 +438,7 @@ impl MirStructure {
         // Iterate over the methods and rename them
         // to their method names, such as `Date::day`
         for function in &self.methods {
-            function.as_method(&self.to_mir_type())
-                .declare(funcs)?;
+            function.as_method(&self.to_mir_type()).declare(funcs)?;
         }
         Ok(())
     }

--- a/src/mir.rs
+++ b/src/mir.rs
@@ -358,22 +358,8 @@ impl MirProgram {
         let mut result = Vec::new();
         for decl in &decls {
             match decl {
-                MirDeclaration::Function(func) => {
-                    let name = func.get_name();
-                    if funcs.contains_key(&name) {
-                        return Err(MirError::FunctionRedefined(name));
-                    } else {
-                        funcs.insert(name, func.clone());
-                    }
-                }
-                MirDeclaration::Structure(structure) => {
-                    let name = structure.get_name();
-                    if structs.contains_key(&name) {
-                        return Err(MirError::StructureRedefined(name));
-                    } else {
-                        structs.insert(structure.get_name(), structure.clone());
-                    }
-                }
+                MirDeclaration::Function(func) => func.declare(&mut funcs)?,
+                MirDeclaration::Structure(structure) => structure.declare(&mut funcs, &mut structs)?,
                 MirDeclaration::Extern(filename) => externs.push(filename.clone()),
             }
         }
@@ -435,6 +421,28 @@ impl MirStructure {
         self.size
     }
 
+    /// Declare the structure to the compiler WITHOUT assembling it
+    fn declare(&self, 
+        funcs: &mut BTreeMap<Identifier, MirFunction>,
+        structs: &mut BTreeMap<Identifier, MirStructure>) -> Result<(), MirError> {
+
+        // Check if the structure has already been declared
+        if structs.contains_key(&self.name) {
+            return Err(MirError::StructureRedefined(self.get_name()));
+        } else {
+            structs.insert(self.get_name(), self.clone());
+        }
+        // Iterate over the methods and rename them
+        // to their method names, such as `Date::day`
+        for function in &self.methods {
+            let method = function.as_method(
+                &MirType::structure(self.get_name())
+            );
+            funcs.insert(method.get_name(), method.clone());
+        }
+        Ok(())
+    }
+
     fn assemble(
         &self,
         funcs: &mut BTreeMap<Identifier, MirFunction>,
@@ -450,13 +458,6 @@ impl MirStructure {
 
         let mir_type = self.to_mir_type();
         let mut result = Vec::new();
-
-        // Iterate over the methods and rename them
-        // to their method names, such as `Date::day`
-        for function in &self.methods {
-            let method = function.as_method(&mir_type);
-            funcs.insert(method.get_name(), method.clone());
-        }
 
         // After each function has been declared, go back and assemble them.
         // We do two passes to allow methods to depend on one another.
@@ -498,6 +499,17 @@ impl MirFunction {
         let mut result = self.clone();
         result.name = mir_type.method_to_function_name(&self.name);
         result
+    }
+
+    /// Declare this function to the compiler WITHOUT assembling it
+    fn declare(&self, funcs: &mut BTreeMap<Identifier, MirFunction>) -> Result<(), MirError> {
+        // Check if the function has already been declared
+        if funcs.contains_key(&self.name) {
+            Err(MirError::FunctionRedefined(self.get_name()))
+        } else {
+            funcs.insert(self.get_name(), self.clone());
+            Ok(())
+        }
     }
 
     fn assemble(

--- a/src/mir.rs
+++ b/src/mir.rs
@@ -435,10 +435,8 @@ impl MirStructure {
         // Iterate over the methods and rename them
         // to their method names, such as `Date::day`
         for function in &self.methods {
-            let method = function.as_method(
-                &MirType::structure(self.get_name())
-            );
-            funcs.insert(method.get_name(), method.clone());
+            function.as_method(&self.to_mir_type())
+                .declare(funcs)?;
         }
         Ok(())
     }


### PR DESCRIPTION
This PR fixes the problem where types' functions could not be used before the type declaration.

Take the following code for example.

```rust
fn main() {
    let t = T::new();
}

type T(1) {
    fn new() -> T {
        return 1 as T;
    }
}
```

Before, this code would throw an error stating that `T::new` has not been declared.

To fix this, the `declare` methods were added to the `MirStructure` and `MirFunction` types. These methods declare the methods of each type and each function _before_ the MIR is compiled, not _during_.