### PR TITLE
Added memory leak error checks at the end of execution

### DIFF
--- a/examples/leak.ok
+++ b/examples/leak.ok
@@ -1,0 +1,6 @@
+#[memory(128)]
+
+
+fn main() {
+    let x = alloc(8) as &char;
+}


### PR DESCRIPTION
This PR adds memory leak checks at the end of execution. All this really does is iterate over the `allocated` bitmask to check if any data has not been freed. If there is still alloc'd data, then the program panics with the error code `4`, and dumps the virtual machines' memory.

Here is some example output.
```
stack: [ ]
heap:  [ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 ]
alloc: [ 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 ]
STACK SIZE    0
TOTAL ALLOC'D 8
panic: leaked heap memory
```