### PR TITLE
Fixed `-o` flag not working for doc subcmd, and markdown changes

### DIFF
--- a/src/bin.rs
+++ b/src/bin.rs
@@ -84,7 +84,7 @@ fn main() {
                 };
 
                 // If the output file exists, write the output to it
-                if let Some(output_file) = matches.value_of("OUTPUT") {
+                if let Some(output_file) = sub_matches.value_of("OUTPUT") {
                     if let Ok(_) = write(output_file, docs) {
                         println!("doc generation successful")
                     } else {

--- a/src/hir.rs
+++ b/src/hir.rs
@@ -467,8 +467,8 @@ impl HirStructure {
     fn generate_docs(&self) -> String {
         // Add a header for the output markdown
         let mut result = format!(
-            "## *type* **{}** *with size* **{}**\n",
-            self.name, self.size
+            "## *type* **{}**\n",
+            self.name
         );
         // If a docstring is defined, then
         // add it to the output
@@ -556,9 +556,11 @@ impl HirFunction {
         for (i, (arg_name, arg_type)) in self.args.iter().enumerate() {
             result += &format!("*{}*: {}, ", arg_name, arg_type)
         }
-        // Remove the last space and comma
-        result.pop();
-        result.pop();
+        // Remove the last space and comma from the last argument
+        if !self.args.is_empty() {
+            result.pop();
+            result.pop();
+        }
 
         // Add the close parantheses
         result += ")";


### PR DESCRIPTION
This addresses issue #66. The `-o` flag was not working for the doc sub-command because the `-o` flag was being looked for in the arguments to the _program_, not the arguments to the `doc` sub-command. This was a one line fix. Additionally, this PR fixes the error where a function with no arguments was documented like so: `fn function_name) -> result_type`.