### PR TITLE
Fix include

### DIFF
--- a/examples/include/lib/all.ok
+++ b/examples/include/lib/all.ok
@@ -1,5 +1,5 @@
 // Include string library
-#[include("str.ok")]
-#[include("str.ok")]
+#[include("../lib/str.ok")]
+#[include("../lib/str.ok")]
 #[include("str.ok")]
 #[include("str.ok")]

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -74,13 +74,21 @@ fn main() {
         if let Some(input_file) = sub_matches.value_of("FILE") {
             // Get the contents of the input file
             if let Ok(contents) = read_to_string(input_file) {
+
+                // Get the current working directory of the input file
+                let cwd = if let Some(dir) = PathBuf::from(input_file).parent() {
+                    PathBuf::from(dir)
+                } else {
+                    PathBuf::from("./")
+                };
+
                 // Document the input file using the target backend
                 let docs = if matches.is_present("cc") {
-                    generate_docs(contents, input_file, C)
+                    generate_docs(&cwd, contents, input_file, C)
                 } else if matches.is_present("go") {
-                    generate_docs(contents, input_file, Go)
+                    generate_docs(&cwd, contents, input_file, Go)
                 } else {
-                    generate_docs(contents, input_file, C)
+                    generate_docs(&cwd, contents, input_file, C)
                 };
 
                 // If the output file exists, write the output to it

--- a/src/hir.rs
+++ b/src/hir.rs
@@ -367,8 +367,6 @@ pub enum HirDeclaration {
     Error(String),
     /// Include a foreign file using the `extern` flag.
     Extern(String),
-    // /// Include an Oak file using the `include` flag.
-    // Include(String),
     /// Set the memory used for the stack and heap.
     Memory(i32),
     /// Mark that the standard library is required for the program

--- a/src/hir.rs
+++ b/src/hir.rs
@@ -160,37 +160,6 @@ impl HirProgram {
                     mir_decls.push(MirDeclaration::Extern(file_path))
                 }
                 HirDeclaration::Error(err) => return Err(HirError::UserError(err.clone())),
-                HirDeclaration::Include(filename) => {
-                    // This takes the path of the file in the `include` flag
-                    // and appends it to the directory of the file which is
-                    // including it.
-                    //
-                    // So, if `src/main.ok` includes "lib/all.ok",
-                    // `file_path` will be equal to "src/lib/all.ok"
-                    let file_path = cwd.join(filename.clone());
-                    if let Ok(contents) = read_to_string(file_path.clone()) {
-                        // Get the directory of the included file.
-
-                        // If `src/main.ok` includes "lib/all.ok",
-                        // `include_path` will be equal to "src/lib/"
-                        let include_path = if let Some(dir) = file_path.parent() {
-                            PathBuf::from(dir)
-                        } else {
-                            PathBuf::from("./")
-                        };
-
-                        // Compile the included file using the `include_path` as
-                        // the current working directory.
-                        mir_decls.extend(
-                            parse(contents)
-                                .compile(&include_path, target, constants)?
-                                .get_declarations(),
-                        );
-                    } else {
-                        eprintln!("error: could not include file '{}'", filename);
-                        exit(1);
-                    }
-                }
 
                 HirDeclaration::If(cond, code) => {
                     if cond.to_value(self.get_declarations(), constants, target)? != 0.0 {
@@ -398,14 +367,16 @@ pub enum HirDeclaration {
     Error(String),
     /// Include a foreign file using the `extern` flag.
     Extern(String),
-    /// Include an Oak file using the `include` flag.
-    Include(String),
+    // /// Include an Oak file using the `include` flag.
+    // Include(String),
     /// Set the memory used for the stack and heap.
     Memory(i32),
     /// Mark that the standard library is required for the program
     RequireStd,
     /// Mark that the standard library is not allowed for the program
     NoStd,
+    /// Do nothing
+    Pass
 }
 
 /// This type represents a user defined structure.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod hir;
 pub mod mir;
 pub mod tir;
 use hir::HirProgram;
+use tir::TirProgram;
 
 mod target;
 pub use target::{Go, Target, C, TS};
@@ -19,7 +20,10 @@ use lalrpop_util::{lalrpop_mod, ParseError};
 lalrpop_mod!(pub parser);
 
 pub fn generate_docs(cwd: &PathBuf, input: impl ToString, filename: impl ToString, target: impl Target) -> String {
-    parse(cwd, input).generate_docs(filename.to_string(), &target, &mut BTreeMap::new(), false)
+    match parse(input).compile(cwd) {
+        Ok(output) => output,
+        Err(e) => print_compile_error(e)
+    }.generate_docs(filename.to_string(), &target, &mut BTreeMap::new(), false)
 }
 
 fn print_compile_error(e: impl Display) -> ! {
@@ -28,10 +32,22 @@ fn print_compile_error(e: impl Display) -> ! {
 }
 
 pub fn compile(cwd: &PathBuf, input: impl ToString, target: impl Target) -> Result<()> {
-    let mut hir = parse(cwd, input);
-    hir.extend_declarations(parse(cwd, include_str!("core.ok")).get_declarations());
+    let mut tir = parse(input);
+    let mut hir = match tir.compile(cwd) {
+        Ok(output) => output,
+        Err(e) => print_compile_error(e)
+    };
+
+    hir.extend_declarations(match parse(include_str!("core.ok")).compile(cwd) {
+        Ok(output) => output,
+        Err(e) => print_compile_error(e)
+    }.get_declarations());
+
     if hir.use_std() {
-        hir.extend_declarations(parse(cwd, include_str!("std.ok")).get_declarations())
+        hir.extend_declarations(match parse(include_str!("std.ok")).compile(cwd) {
+            Ok(output) => output,
+            Err(e) => print_compile_error(e)
+        }.get_declarations());
     }
 
     match hir.compile(cwd, &target, &mut BTreeMap::new()) {
@@ -50,16 +66,11 @@ pub fn compile(cwd: &PathBuf, input: impl ToString, target: impl Target) -> Resu
     }
 }
 
-pub fn parse(cwd: &PathBuf, input: impl ToString) -> HirProgram {
+pub fn parse(input: impl ToString) -> TirProgram {
     let code = &strip(input.to_string()).unwrap();
     match parser::ProgramParser::new().parse(code) {
         // if the parser succeeds, build will succeed
-        Ok(parsed) => match parsed.compile(cwd) {
-            Ok(result) => result,
-            Err(e) => {
-                print_compile_error(e);
-            }
-        },
+        Ok(parsed) => parsed,
         // if the parser succeeds, annotate code with comments
         Err(e) => {
             eprintln!("{}", format_error(&code, e));

--- a/src/mir.rs
+++ b/src/mir.rs
@@ -2133,7 +2133,7 @@ impl Display for MirExpression {
 
             Self::Add(lhs, rhs) => write!(f, "{}+{}", lhs, rhs),
             Self::Subtract(lhs, rhs) => write!(f, "{}-{}", lhs, rhs),
-            Self::Multiply(lhs, rhs) => write!(f, "{}/{}", lhs, rhs),
+            Self::Multiply(lhs, rhs) => write!(f, "{}*{}", lhs, rhs),
             Self::Divide(lhs, rhs) => write!(f, "{}/{}", lhs, rhs),
 
             Self::Equal(lhs, rhs) => write!(f, "{}=={}", lhs, rhs),

--- a/src/tir.rs
+++ b/src/tir.rs
@@ -90,7 +90,7 @@ impl TirProgram {
                     // Compile the included file using the `include_path` as
                     // the current working directory.
                     hir_decls.extend(
-                        parse(cwd, contents)
+                        parse(&include_path, contents)
                             .get_declarations()
                             .clone()
                     );


### PR DESCRIPTION
This PR moves the `include` directive logic into TIR. This fixes not being able to include structures from other files. This has various consequences; the largest changes occur in `lib.rs` and its `parse` function, which now returns a TIR program instead of an HIR program. 