### PR TITLE
Implemented the `extern` keyword

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oakc"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Adam McDaniel <adam.mcdaniel17@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/examples/ffi/lib/foreign.c
+++ b/examples/ffi/lib/foreign.c
@@ -3,3 +3,10 @@
 void test(machine *vm) {
     printf("This is a C foreign function!\n");
 }
+
+void __oak_add(machine *vm) {
+    int a = machine_pop(vm);
+    int b = machine_pop(vm);
+    printf("This should print %d => ", a + b);
+    machine_push(vm, a + b);
+}

--- a/examples/ffi/lib/foreign.go
+++ b/examples/ffi/lib/foreign.go
@@ -2,3 +2,10 @@
 func test(vm *machine) {
 	fmt.Println("This is a Go foreign function!")
 }
+
+func __oak_add(vm *machine) {
+	a := vm.pop()
+	b := vm.pop()
+	fmt.Printf("This should print %v => ", a+b)
+	vm.push(float64(a + b))
+}

--- a/examples/ffi/lib/foreign.ok
+++ b/examples/ffi/lib/foreign.ok
@@ -9,4 +9,5 @@
     }]
 }]
 
-fn test() { test!() }
+extern fn test();
+extern fn __oak_add as add(a: num, b: num) -> num;

--- a/examples/ffi/main.ok
+++ b/examples/ffi/main.ok
@@ -1,6 +1,7 @@
-#[no_std]
+#[std]
 #[include("lib/foreign.ok")]
 
 fn main() {
 	test();
+	putnumln(add(5, 6));
 }

--- a/src/parser.lalrpop
+++ b/src/parser.lalrpop
@@ -5,6 +5,8 @@ grammar;
 
 pub Program: TirProgram = <(Declaration)*> => TirProgram::new(<>, 512);
 
+Doc: String = "#" "[" "doc" "(" <Str> ")" "]" => <>;
+
 Declaration: TirDeclaration = {
     "#" "[" "header" "(" <Str> ")" "]" => TirDeclaration::DocumentHeader(<>),
     "#" "[" "std" "]" => TirDeclaration::RequireStd,
@@ -17,8 +19,14 @@ Declaration: TirDeclaration = {
     "#" "[" "if" "(" <cond:Constant> ")" "{" <code:Program> "}" "]" => TirDeclaration::If(cond, code),
     "#" "[" "if" "(" <cond:Constant> ")" "{" <then_code:Program> "}" "else" "{" <else_code:Program> "}" "]" => TirDeclaration::IfElse(cond, then_code, else_code),
     "#" "[" "define" "(" <name:Str> "," <constant:Constant> ")" "]" => TirDeclaration::Constant(None, name, constant),
-    "#" "[" "doc" "(" <doc:Str> ")" "]" "const" <name:Ident> "=" <constant:Constant> ";" => TirDeclaration::Constant(Some(doc), name, constant),
-    "const" <name:Ident> "=" <constant:Constant> ";" => TirDeclaration::Constant(None, name, constant),
+    
+    <doc:Doc?> "const" <name:Ident> "=" <constant:Constant> ";" => TirDeclaration::Constant(doc, name, constant),
+    
+    <doc:Doc?> "extern" "fn" <name:Ident> <params:Params> ";" => TirDeclaration::ExternFunction(doc, name.clone(), name, params, TirType::Void), 
+    <doc:Doc?> "extern" "fn" <name:Ident> <params:Params> "->" <return_type:Type> ";" => TirDeclaration::ExternFunction(doc, name.clone(), name, params, return_type),
+    <doc:Doc?> "extern" "fn" <foreign_name:Ident> "as" <name:Ident> <params:Params> ";" => TirDeclaration::ExternFunction(<>, TirType::Void), 
+    <doc:Doc?> "extern" "fn" <foreign_name:Ident> "as" <name:Ident> <params:Params> "->" <return_type:Type> ";" => TirDeclaration::ExternFunction(<>),
+
     <Function> => TirDeclaration::Function(<>),
     <Structure> => TirDeclaration::Structure(<>),
 }
@@ -56,6 +64,8 @@ List<Begin, T, Sep, End>: Vec<T> = {
         }
     }
 }
+
+Params: Vec<(Identifier, TirType)> = <args:List<"(", (Ident ":" Type), ",", ")">> => args.iter().map(|(a, _, t)| (a.clone(), t.clone())).collect();
 
 Constant: TirConstant = {
     <cond:ConstantMathBottom> "?" <then:Constant> ":" <otherwise:Constant> => TirConstant::Conditional(Box::new(cond), Box::new(then), Box::new(otherwise)),
@@ -104,15 +114,12 @@ ConstantMathHigh: TirConstant = {
 }
 
 Function: TirFunction = {
-    "#" "[" "doc" "(" <doc:Str> ")" "]" "fn" <name:Ident> <args:List<"(", (Ident ":" Type), ",", ")">> <body:Body> => TirFunction::new(Some(doc), name, args.iter().map(|(a, _, t)| (a.clone(), t.clone())).collect(), TirType::Void, body),
-    "#" "[" "doc" "(" <doc:Str> ")" "]" "fn" <name:Ident> <args:List<"(", (Ident ":" Type), ",", ")">> "->" <return_type:Type> <body:Body> => TirFunction::new(Some(doc), name, args.iter().map(|(a, _, t)| (a.clone(), t.clone())).collect(), return_type, body),
-    "fn" <name:Ident> <args:List<"(", (Ident ":" Type), ",", ")">> <body:Body> => TirFunction::new(None, name, args.iter().map(|(a, _, t)| (a.clone(), t.clone())).collect(), TirType::Void, body),
-    "fn" <name:Ident> <args:List<"(", (Ident ":" Type), ",", ")">> "->" <return_type:Type> <body:Body> => TirFunction::new(None, name, args.iter().map(|(a, _, t)| (a.clone(), t.clone())).collect(), return_type, body),
+    <doc:Doc?> "fn" <name:Ident> <params:Params> <body:Body> => TirFunction::new(doc, name, params, TirType::Void, body),
+    <doc:Doc?> "fn" <name:Ident> <params:Params> "->" <return_type:Type> <body:Body> => TirFunction::new(doc, name, params, return_type, body),
 }
 
 Structure: TirStructure = {
-    "#" "[" "doc" "(" <doc:Str> ")" "]" "struct" <name:Ident> "{" <members: List<"let", (Ident ":" Type), ",", ";">> <methods:Function*> "}" => TirStructure::new(Some(doc), name, members.iter().map(|(a, _, t)| (a.clone(), t.clone())).collect(), methods),
-    "struct" <name:Ident> "{" <members: List<"let", (Ident ":" Type), ",", ";">> <methods:Function*> "}" => TirStructure::new(None, name, members.iter().map(|(a, _, t)| (a.clone(), t.clone())).collect(), methods),
+    <doc:Doc?> "struct" <name:Ident> "{" <members: List<"let", (Ident ":" Type), ",", ";">> <methods:Function*> "}" => TirStructure::new(doc, name, members.iter().map(|(a, _, t)| (a.clone(), t.clone())).collect(), methods),
 }
 
 Body: Vec<TirStatement> = "{" <head: Statement*> <tail: SmallStatement?> "}" => {
@@ -196,7 +203,6 @@ ExpressionAtom: TirExpression = {
     "sizeof" "(" <Type> ")" => TirExpression::SizeOf(<>),
     "alloc" "(" <size:Expression> ")" => TirExpression::Alloc(Box::new(size)),
     <name:Ident> <args:List<"(", Expression, ",", ")">> => TirExpression::Call(name, args),
-    <name:Ident> "!" <args:List<"(", Expression, ",", ")">> => TirExpression::ForeignCall(name, args),
 
     "true" => TirExpression::True,
     "false" => TirExpression::False,

--- a/src/std.ok
+++ b/src/std.ok
@@ -1,12 +1,15 @@
 
-fn putstr(s: &char) -> void { prs!(s); }
-fn putstrln(s: &char) -> void { putstr(s); prend!(); }
+extern fn prend();
+extern fn prs as putstr(s: &char);
+extern fn prn as putnum(n: num);
+extern fn prc as putchar(ch: char);
+extern fn getch as get_char() -> char;
 
-fn putnum(n: num) -> void { prn!(n); }
-fn putnumln(n: num) -> void { putnum(n); prend!(); }
+fn putstrln(s: &char) -> void { putstr(s); prend(); }
 
-fn putchar(ch: char) -> void { prc!(ch); }
-fn putcharln(ch: char) -> void { putchar(ch); prend!(); }
+fn putnumln(n: num) -> void { putnum(n); prend(); }
+
+fn putcharln(ch: char) -> void { putchar(ch); prend(); }
 
 fn putbool(b: bool) -> void {
     if b {
@@ -24,6 +27,4 @@ fn putbool(b: bool) -> void {
     }
 }
 
-fn putboolln(b: bool) -> void { putbool(b); prend!(); }
-
-fn get_char() -> char { return getch!() as char; }
+fn putboolln(b: bool) -> void { putbool(b); prend(); }


### PR DESCRIPTION
This implements the `extern` keyword and adds a fix where the `extern` directive could not grab files in subdirectories. It also removes the `foreign_fn!()` syntax.

Here's the example in the `ffi` subdirectory.

```rust
// foreign.ok

#[if(TARGET == 'c') {
    #[extern("foreign.c")]
} else {
    #[if(TARGET == 'g') {
        #[extern("foreign.go")]
    } else {
        #[error("this program only supports go and c backends")]
    }]
}]

extern fn test();
extern fn __oak_add as add(a: num, b: num) -> num;
```

These foreign functions can then be used like so:
```rust
// main.ok
#[std]
#[include("lib/foreign.ok")]

fn main() {
    test();
    putnumln(add(5, 6));
}
```

This PR also applies the fix for #68 to the `extern` directive, and also to each of the sub-directives in every conditional compilation directive.