### PR TITLE
Made TirConstant the same as HirConstant, and moved conditional compilation to TIR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oakc"
-version = "0.6.3"
+version = "0.6.4"
 authors = ["Adam McDaniel <adam.mcdaniel17@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/src/parser.lalrpop
+++ b/src/parser.lalrpop
@@ -83,8 +83,7 @@ Constant: TirConstant = {
 
 ConstantAtom: TirConstant = {
     <offset:@L> "current_line" "(" ")" => TirConstant::Float(get_line(script, offset).0 as f64),
-    "is_movable" "(" <Type> ")" => TirConstant::IsMovable(<>),
-    "sizeof" "(" <Type> ")" => TirConstant::SizeOf(<>),
+    "sizeof" "(" <Type> ")" => TirConstant::SizeOf(<>.to_hir_type()),
     "is_defined" "(" <Str> ")" => TirConstant::IsDefined(<>),
     "true" => TirConstant::True,
     "false" => TirConstant::False,

--- a/src/tir.rs
+++ b/src/tir.rs
@@ -166,8 +166,9 @@ impl TirProgram {
                     // Remove the include directive so it does not get computed again
                     self.get_declarations().remove(i);
 
-                    // Add the contents of the included file to this file
                     if let Ok(val) = cond.to_value(&hir_decls, constants) {
+                        // If the constant expression evaluates to true,
+                        // Then add the contents of the block to this program.
                         if val != 0.0 {
                             self.get_declarations()
                                 .extend(code.clone().get_declarations().clone());
@@ -184,10 +185,14 @@ impl TirProgram {
 
                     // Add the contents of the included file to this file
                     if let Ok(val) = cond.to_value(&hir_decls, constants) {
+                        // If the constant expression evaluates to true,
                         if val != 0.0 {
+                            // Then add the contents of the block to this program.
                             self.get_declarations()
                                 .extend(then_code.clone().get_declarations().clone());
                         } else {
+                            // Otherwise, add the contents of the `else` block
+                            // to this program.
                             self.get_declarations()
                                 .extend(else_code.clone().get_declarations().clone());
                         }


### PR DESCRIPTION
This needed to be done for the same reason as #74: structures need to be made available to TIR to determine their movability. Structures defined in `if` compiler flag blocks could not be processed by TIR (before this PR). To fix this, I made some adjustments to TIR to allow conditional compilation statements to be computed before HIR. This completely fixes the issue of not being able to `import` structures from other files.