### PR TITLE
Fix/if

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oakc"
-version = "0.6.5"
+version = "0.6.6"
 authors = ["Adam McDaniel <adam.mcdaniel17@gmail.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
Before, all `if` statements were managed by hidden `%IF_VAR%` and `%ELSE_VAR%` variables used as the conditions. This is because loops and if statements function identically in the backend, so if statements must have some way to exit the loop. This works perfectly for nested `if` statements, but the problem really arises with nested `if` `else` statements. Now, these variables are numbered as they are assembled into `Asm` by `Mir`, similarly to how instances of non-memcopy structures are assigned numbered hidden variables.