### PR TITLE
Implement foreign functions to have their own representation in the different IR levels

### DIFF
--- a/src/tir.rs
+++ b/src/tir.rs
@@ -8,7 +8,7 @@ use std::{
 
 use crate::{
     hir::{
-        HirConstant, HirDeclaration, HirExpression, HirFunction, HirProgram, HirStatement,
+        HirConstant, HirDeclaration, HirExpression, HirFunction, HirForeignFunction, HirProgram, HirStatement,
         HirStructure, HirType,
     },
     parse, Identifier, StringLiteral, Target,
@@ -291,33 +291,12 @@ impl TirDeclaration {
                     hir_args.push(HirExpression::Variable(param.clone()))
                 }
 
-                HirDeclaration::Function(HirFunction::new(
+                HirDeclaration::ForeignFunction(HirForeignFunction::new(
                     doc.clone(),
                     name.clone(),
+                    foreign_name.clone(),
                     hir_params,
                     hir_return_type.clone(),
-                    vec![
-                        // If the return type is not void, then return the result
-                        // of the foreign function
-                        if *return_type != TirType::Void {
-                            HirStatement::Return(vec![
-                                // Foreign functions, by default, return &void for casting purposes
-                                // To get the value we want, we cast it to the requested return type.
-                                HirExpression::TypeCast(
-                                    Box::new(HirExpression::ForeignCall(
-                                        foreign_name.clone(),
-                                        hir_args,
-                                    )),
-                                    hir_return_type,
-                                ),
-                            ])
-                        } else {
-                            HirStatement::Expression(HirExpression::ForeignCall(
-                                foreign_name.clone(),
-                                hir_args,
-                            ))
-                        },
-                    ],
                 ))
             }
 


### PR DESCRIPTION
I was banging my head against the current implementation of `extern fn`'s as it wraps every external function declaration into an oak function. This would generate code to build up/tear down the stackframe and passes all the variables to the actual foreign function. 

This PR is working towards more flexibility by being able to represent `extern fn` declarations as their own thing inside each IR level. The old code generated an oak function with a (return) statement of the foreign function call as single statement inside its body. I moved that logic from the `Tir` level to the `Mir` level as this currently does not change anything in the generated code.

I would like to propose to implement hooks for the `Target` implementations to generate the following code:
- setup logic to pass the parameters to the foreign function in a manner that does not require the foreign function to know how to manage the oak vm.
- call the foreign function (this is already done with `Target::call_foreign_function(name: String)`
- setup logic to pass the return value back to the vm

Currently you have to write code in the target language to wrap any foreign functions before you can use them. These changes would generate all the needed code for you.

The challenges i'm facing now:
- Make it simple. Generating code to pass a dynamic amount of variables for each function call requires the `Target` implementation to know a bit about the `Asm` representation.
- Make it generic. Preferably the current behaviour would be the default (set up stack/variables and tear them down after the foreign function call). If a `Target` implements certain hooks then the default would be ignored and the compiler relies on the implementation of the target backend.

Added bonus is that this PR also allows the documentation generator to differ between native and foreign functions.

Any idea's?